### PR TITLE
Kp 92 rebase recurly lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The library is distributed via [Maven Central](http://search.maven.org/#search%7
 <dependency>
     <groupId>com.ning.billing</groupId>
     <artifactId>recurly-java-library</artifactId>
-    <version>0.11.0</version>
+    <version>0.13.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <groupId>com.ning.billing</groupId>
     <artifactId>recurly-java-library</artifactId>
     <packaging>jar</packaging>
-    <version>0.11.1-SNAPSHOT</version>
+    <version>0.12.0</version>
     <name>Recurly Java library</name>
     <description>Java library for Recurly</description>
     <url>http://github.com/killbilling/recurly-java-library</url>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <groupId>com.ning.billing</groupId>
     <artifactId>recurly-java-library</artifactId>
     <packaging>jar</packaging>
-    <version>0.13.0</version>
+    <version>0.13.1-SNAPSHOT</version>
     <name>Recurly Java library</name>
     <description>Java library for Recurly</description>
     <url>http://github.com/killbilling/recurly-java-library</url>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <groupId>com.ning.billing</groupId>
     <artifactId>recurly-java-library</artifactId>
     <packaging>jar</packaging>
-    <version>0.12.1-SNAPSHOT</version>
+    <version>0.13.0</version>
     <name>Recurly Java library</name>
     <description>Java library for Recurly</description>
     <url>http://github.com/killbilling/recurly-java-library</url>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <groupId>com.ning.billing</groupId>
     <artifactId>recurly-java-library</artifactId>
     <packaging>jar</packaging>
-    <version>0.12.0</version>
+    <version>0.12.1-SNAPSHOT</version>
     <name>Recurly Java library</name>
     <description>Java library for Recurly</description>
     <url>http://github.com/killbilling/recurly-java-library</url>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <groupId>com.ning.billing</groupId>
     <artifactId>recurly-java-library</artifactId>
     <packaging>jar</packaging>
-    <version>0.13.1-SNAPSHOT</version>
+    <version>0.13.1</version>
     <name>Recurly Java library</name>
     <description>Java library for Recurly</description>
     <url>http://github.com/killbilling/recurly-java-library</url>

--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -102,7 +102,7 @@ public class RecurlyClient {
     private static final Logger log = LoggerFactory.getLogger(RecurlyClient.class);
 
     public static final String RECURLY_DEBUG_KEY = "recurly.debug";
-    public static final String RECURLY_API_VERSION = "2.8";
+    public static final String RECURLY_API_VERSION = "2.9";
 
     private static final String X_RECORDS_HEADER_NAME = "X-Records";
     private static final String LINK_HEADER_NAME = "Link";
@@ -534,6 +534,22 @@ public class RecurlyClient {
     public Subscriptions getSubscriptions() {
         return doGET(Subscriptions.SUBSCRIPTIONS_RESOURCE,
                 Subscriptions.class);
+    }
+
+    /**
+     * Get all the subscriptions on the site given some sort and filter params.
+     * <p>
+     * Returns all the subscriptions on the site
+     *
+     * @param state {@link SubscriptionState}
+     * @param params {@link QueryParams}
+     * @return Subscriptions on the site
+     */
+    public Subscriptions getSubscriptions(final SubscriptionState state, final QueryParams params) {
+        if (state != null) { params.put("state", state.getType()); }
+
+        return doGET(Subscriptions.SUBSCRIPTIONS_RESOURCE,
+                Subscriptions.class, params);
     }
 
     /**
@@ -1496,6 +1512,25 @@ public class RecurlyClient {
      */
     public Invoice previewPurchase(final Purchase purchase) {
         return doPOST(Purchase.PURCHASES_ENDPOINT + "/preview", purchase, Invoice.class);
+    }
+
+    /**
+     * Purchases authorize endpoint.
+     *
+     * Generate an authorized invoice for the purchase. Runs validations
+     + but does not run any transactions. This endpoint will create a
+     + pending purchase that can be activated at a later time once payment
+     + has been completed on an external source (e.g. Adyen's Hosted
+     + Payment Pages).
+     *
+     * <p>
+     * https://dev.recurly.com/docs/authorize-purchase
+     *
+     * @param purchase The purchase data
+     * @return The authorized invoice
+     */
+    public Invoice authorizePurchase(final Purchase purchase) {
+        return doPOST(Purchase.PURCHASES_ENDPOINT + "/authorize", purchase, Invoice.class);
     }
 
     /**

--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -102,7 +102,7 @@ public class RecurlyClient {
     private static final Logger log = LoggerFactory.getLogger(RecurlyClient.class);
 
     public static final String RECURLY_DEBUG_KEY = "recurly.debug";
-    public static final String RECURLY_API_VERSION = "2.7";
+    public static final String RECURLY_API_VERSION = "2.8";
 
     private static final String X_RECORDS_HEADER_NAME = "X-Records";
     private static final String LINK_HEADER_NAME = "Link";

--- a/src/main/java/com/ning/billing/recurly/model/BillingInfo.java
+++ b/src/main/java/com/ning/billing/recurly/model/BillingInfo.java
@@ -20,6 +20,7 @@ package com.ning.billing.recurly.model;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
+import javax.xml.bind.annotation.XmlAttribute;
 
 import com.google.common.base.Objects;
 import org.joda.time.DateTime;
@@ -29,6 +30,9 @@ public class BillingInfo extends RecurlyObject {
 
     @XmlTransient
     public static final String BILLING_INFO_RESOURCE = "/billing_info";
+
+    @XmlAttribute(name="type")
+    private String type;
 
     @XmlElement(name = "account")
     private Account account;
@@ -101,6 +105,15 @@ public class BillingInfo extends RecurlyObject {
 
     @XmlElement(name = "updated_at")
     private DateTime updatedAt;
+
+
+    public String getType() {
+        return type;
+    }
+
+    protected void setType(final Object type) {
+        this.type = stringOrNull(type);
+    }
 
     /**
      * Account object associated to this BillingInfo
@@ -305,6 +318,7 @@ public class BillingInfo extends RecurlyObject {
         final StringBuilder sb = new StringBuilder();
         sb.append("BillingInfo");
         sb.append("{account='").append(account).append('\'');
+        sb.append(", type='").append(type).append('\'');
         sb.append(", firstName='").append(firstName).append('\'');
         sb.append(", lastName='").append(lastName).append('\'');
         sb.append(", company='").append(company).append('\'');
@@ -384,6 +398,9 @@ public class BillingInfo extends RecurlyObject {
         if (state != null ? !state.equals(that.state) : that.state != null) {
             return false;
         }
+        if (type != null ? !type.equals(that.type) : that.type != null) {
+            return false;
+        }
         if (vatNumber != null ? !vatNumber.equals(that.vatNumber) : that.vatNumber != null) {
             return false;
         }
@@ -426,7 +443,8 @@ public class BillingInfo extends RecurlyObject {
                 firstSix,
                 lastFour,
                 updatedAt,
-                geoCode
+                geoCode,
+                type
         );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/BillingInfo.java
+++ b/src/main/java/com/ning/billing/recurly/model/BillingInfo.java
@@ -106,6 +106,8 @@ public class BillingInfo extends RecurlyObject {
     @XmlElement(name = "updated_at")
     private DateTime updatedAt;
 
+    @XmlElement(name = "external_hpp_type")
+    private String externalHppType;
 
     public String getType() {
         return type;
@@ -313,6 +315,10 @@ public class BillingInfo extends RecurlyObject {
         this.updatedAt = dateTimeOrNull(updatedAt);
     }
 
+    public String getExternalHppType() { return externalHppType; }
+
+    public void setExternalHppType(final Object externalHppType) { this.externalHppType = stringOrNull(externalHppType); }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
@@ -339,6 +345,7 @@ public class BillingInfo extends RecurlyObject {
         sb.append(", lastFour='").append(lastFour).append('\'');
         sb.append(", geoCode='").append(geoCode).append('\'');
         sb.append(", updatedAt='").append(updatedAt).append('\'');
+        sb.append(", externalHppType='").append(externalHppType).append('\'');
         sb.append('}');
         return sb.toString();
     }
@@ -416,6 +423,9 @@ public class BillingInfo extends RecurlyObject {
         if (updatedAt != null ? updatedAt.compareTo(that.updatedAt) != 0 : that.updatedAt != null) {
             return false;
         }
+        if (externalHppType != null ? !externalHppType.equals(that.externalHppType) : that.externalHppType != null) {
+            return false;
+        }
 
         return true;
     }
@@ -444,7 +454,8 @@ public class BillingInfo extends RecurlyObject {
                 lastFour,
                 updatedAt,
                 geoCode,
-                type
+                type,
+                externalHppType
         );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/Invoice.java
+++ b/src/main/java/com/ning/billing/recurly/model/Invoice.java
@@ -106,6 +106,15 @@ public class Invoice extends RecurlyObject {
     @XmlElement(name = "transaction")
     private Transactions transactions;
 
+    @XmlElement(name = "customer_notes")
+    private String customerNotes;
+
+    @XmlElement(name = "terms_and_conditions")
+    private String termsAndConditions;
+
+    @XmlElement(name = "vat_reverse_charge_notes")
+    private String vatReverseChargeNotes;
+
     public Account getAccount() {
         if (account != null && account.getCreatedAt() == null) {
             account = fetch(account, Account.class);
@@ -329,6 +338,30 @@ public class Invoice extends RecurlyObject {
         this.transactions = transactions;
     }
 
+    public String getCustomerNotes() {
+        return customerNotes;
+    }
+
+    public void setCustomerNotes(final Object customerNotes) {
+        this.customerNotes = stringOrNull(customerNotes);
+    }
+
+    public String getTermsAndConditions() {
+        return termsAndConditions;
+    }
+
+    public void setTermsAndConditions(final Object termsAndConditions) {
+        this.termsAndConditions = stringOrNull(termsAndConditions);
+    }
+
+    public String getVatReverseChargeNotes() {
+        return vatReverseChargeNotes;
+    }
+
+    public void setVatReverseChargeNotes(final Object vatReverseChargeNotes) {
+        this.vatReverseChargeNotes = stringOrNull(vatReverseChargeNotes);
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("Invoice{");
@@ -357,6 +390,9 @@ public class Invoice extends RecurlyObject {
         sb.append(", recoveryReason=").append(recoveryReason);
         sb.append(", lineItems=").append(lineItems);
         sb.append(", transactions=").append(transactions);
+        sb.append(", customerNotes='").append(customerNotes).append('\'');
+        sb.append(", termsAndConditions='").append(termsAndConditions).append('\'');
+        sb.append(", vatReverseChargeNotes='").append(vatReverseChargeNotes).append('\'');
         sb.append('}');
         return sb.toString();
     }
@@ -387,6 +423,9 @@ public class Invoice extends RecurlyObject {
             return false;
         }
         if (currency != null ? !currency.equals(invoice.currency) : invoice.currency != null) {
+            return false;
+        }
+        if (customerNotes != null ? !customerNotes.equals(invoice.customerNotes) : invoice.customerNotes != null) {
             return false;
         }
         if (invoiceNumber != null ? !invoiceNumber.equals(invoice.invoiceNumber) : invoice.invoiceNumber != null) {
@@ -431,6 +470,9 @@ public class Invoice extends RecurlyObject {
         if (taxRate != null ? !taxRate.equals(invoice.taxRate) : invoice.taxRate != null) {
           return false;
         }
+        if (termsAndConditions != null ? !termsAndConditions.equals(invoice.termsAndConditions) : invoice.termsAndConditions != null) {
+            return false;
+        }
         if (transactions != null ? !transactions.equals(invoice.transactions) : invoice.transactions != null) {
             return false;
         }
@@ -441,6 +483,9 @@ public class Invoice extends RecurlyObject {
             return false;
         }
         if (vatNumber != null ? !vatNumber.equals(invoice.vatNumber) : invoice.vatNumber != null) {
+            return false;
+        }
+        if (vatReverseChargeNotes != null ? !vatReverseChargeNotes.equals(invoice.vatReverseChargeNotes) : invoice.vatReverseChargeNotes != null) {
             return false;
         }
 
@@ -474,7 +519,10 @@ public class Invoice extends RecurlyObject {
                 attemptNextCollectionAt,
                 recoveryReason,
                 lineItems,
-                transactions
+                transactions,
+                customerNotes,
+                termsAndConditions,
+                vatReverseChargeNotes
         );
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/Purchase.java
+++ b/src/main/java/com/ning/billing/recurly/model/Purchase.java
@@ -58,6 +58,15 @@ public class Purchase extends RecurlyObject {
     @XmlElement(name = "gift_card")
     private GiftCard giftCard;
 
+    @XmlElement(name = "customer_notes")
+    private String customerNotes;
+
+    @XmlElement(name = "vat_reverse_charge_notes")
+    private String vatReverseChargeNotes;
+
+    @XmlElement(name = "terms_and_conditions")
+    private String termsAndConditions;
+
     @XmlList
     @XmlElementWrapper(name = "coupon_codes")
     @XmlElement(name = "coupon_code")
@@ -135,6 +144,30 @@ public class Purchase extends RecurlyObject {
         return subscriptions;
     }
 
+    public String getCustomerNotes() {
+        return customerNotes;
+    }
+
+    public void setCustomerNotes(final Object customerNotes) {
+        this.customerNotes = stringOrNull(customerNotes);
+    }
+
+    public String getTermsAndConditions() {
+        return termsAndConditions;
+    }
+
+    public void setTermsAndConditions(final Object termsAndConditions) {
+        this.termsAndConditions = stringOrNull(termsAndConditions);
+    }
+
+    public String getVatReverseChargeNotes() {
+        return vatReverseChargeNotes;
+    }
+
+    public void setVatReverseChargeNotes(final Object vatReverseChargeNotes) {
+        this.vatReverseChargeNotes = stringOrNull(vatReverseChargeNotes);
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
@@ -148,6 +181,9 @@ public class Purchase extends RecurlyObject {
         sb.append(", giftCard='").append(giftCard).append('\'');
         sb.append(", subscriptions='").append(subscriptions).append('\'');
         sb.append(", couponCodes='").append(couponCodes).append('\'');
+        sb.append(", customerNotes='").append(customerNotes).append('\'');
+        sb.append(", termsAndConditions='").append(termsAndConditions).append('\'');
+        sb.append(", vatReverseChargeNotes='").append(vatReverseChargeNotes).append('\'');
         sb.append('}');
         return sb.toString();
     }
@@ -174,6 +210,9 @@ public class Purchase extends RecurlyObject {
         if (currency != null ? !currency.equals(purchase.currency) : purchase.currency != null) {
             return false;
         }
+        if (customerNotes != null ? !customerNotes.equals(purchase.customerNotes) : purchase.customerNotes != null) {
+            return false;
+        }
         if (giftCard != null ? !giftCard.equals(purchase.giftCard) : purchase.giftCard != null) {
             return false;
         }
@@ -184,6 +223,12 @@ public class Purchase extends RecurlyObject {
             return false;
         }
         if (subscriptions != null ? !subscriptions.equals(purchase.subscriptions) : purchase.subscriptions != null) {
+            return false;
+        }
+        if (termsAndConditions != null ? !termsAndConditions.equals(purchase.termsAndConditions) : purchase.termsAndConditions != null) {
+            return false;
+        }
+        if (vatReverseChargeNotes != null ? !vatReverseChargeNotes.equals(purchase.vatReverseChargeNotes) : purchase.vatReverseChargeNotes != null) {
             return false;
         }
 
@@ -201,7 +246,10 @@ public class Purchase extends RecurlyObject {
                 poNumber,
                 netTerms,
                 subscriptions,
-                couponCodes
+                couponCodes,
+                customerNotes,
+                termsAndConditions,
+                vatReverseChargeNotes
         );
     }
 

--- a/src/main/java/com/ning/billing/recurly/model/Purchase.java
+++ b/src/main/java/com/ning/billing/recurly/model/Purchase.java
@@ -42,7 +42,7 @@ public class Purchase extends RecurlyObject {
     private String poNumber;
 
     @XmlElement(name = "net_terms")
-    private String netTerms;
+    private Integer netTerms;
 
     @XmlElement(name = "account")
     private Account account;
@@ -112,12 +112,12 @@ public class Purchase extends RecurlyObject {
         this.giftCard = giftCard;
     }
 
-    public String getNetTerms() {
+    public Integer getNetTerms() {
         return netTerms;
     }
 
     public void setNetTerms(final Object terms) {
-        this.netTerms = stringOrNull(terms);
+        this.netTerms = integerOrNull(terms);
     }
 
     public String getPoNumber() {

--- a/src/main/java/com/ning/billing/recurly/model/Subscription.java
+++ b/src/main/java/com/ning/billing/recurly/model/Subscription.java
@@ -145,6 +145,9 @@ public class Subscription extends AbstractSubscription {
     @XmlElement(name = "no_billing_info_reason")
     public String noBillingInfoReason;
 
+    @XmlElement(name = "imported_trial")
+    public Boolean importedTrial;
+
     public Account getAccount() {
         if (account != null && account.getHref() != null && !account.getHref().isEmpty()) {
             account = fetch(account, Account.class);
@@ -435,6 +438,15 @@ public class Subscription extends AbstractSubscription {
         this.noBillingInfoReason = stringOrNull(noBillingInfoReason);
     }
 
+    public Boolean getImportedTrial() {
+        return this.importedTrial;
+    }
+
+    public void setImportedTrial(final Object importedTrial) {
+        this.importedTrial = booleanOrNull(importedTrial);
+    }
+
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
@@ -473,6 +485,7 @@ public class Subscription extends AbstractSubscription {
         sb.append(", startedWithGift=").append(startedWithGift);
         sb.append(", convertedAt=").append(convertedAt);
         sb.append(", noBillingInfoReason=").append(noBillingInfoReason);
+        sb.append(", importedTrial=").append(importedTrial);
         sb.append('}');
         return sb.toString();
     }
@@ -512,6 +525,9 @@ public class Subscription extends AbstractSubscription {
             return false;
         }
         if (expiresAt != null ? expiresAt.compareTo(that.expiresAt) != 0 : that.expiresAt != null) {
+            return false;
+        }
+        if (importedTrial != null ? !importedTrial.equals(that.importedTrial) : that.importedTrial != null) {
             return false;
         }
         if (remainingBillingCycles != null ? !remainingBillingCycles.equals(that.remainingBillingCycles) : that.remainingBillingCycles != null) {
@@ -630,7 +646,8 @@ public class Subscription extends AbstractSubscription {
                 couponCodes,
                 convertedAt,
                 startedWithGift,
-                noBillingInfoReason
+                noBillingInfoReason,
+                importedTrial
         );
     }
 

--- a/src/main/java/com/ning/billing/recurly/model/push/Notification.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/Notification.java
@@ -50,7 +50,8 @@ public abstract class Notification extends RecurlyObject {
         ClosedInvoiceNotification(com.ning.billing.recurly.model.push.invoice.ClosedInvoiceNotification.class),
         NewInvoiceNotification(com.ning.billing.recurly.model.push.invoice.NewInvoiceNotification.class),
         PastDueInvoiceNotification(com.ning.billing.recurly.model.push.invoice.PastDueInvoiceNotification.class),
-        ProcessingInvoiceNotification(com.ning.billing.recurly.model.push.invoice.ProcessingInvoiceNotification.class);
+        ProcessingInvoiceNotification(com.ning.billing.recurly.model.push.invoice.ProcessingInvoiceNotification.class),
+        UpdatedAccountNotification(com.ning.billing.recurly.model.push.account.UpdatedAccountNotification.class);
 
         private Class<? extends Notification> javaType;
 

--- a/src/main/java/com/ning/billing/recurly/model/push/Notification.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/Notification.java
@@ -31,7 +31,7 @@ import com.google.common.base.CaseFormat;
 public abstract class Notification extends RecurlyObject {
 
     private static Logger log = LoggerFactory.getLogger(Notification.class);
-    private static Pattern ROOT_NAME = Pattern.compile("<(.*_notification)>");
+    private static Pattern ROOT_NAME = Pattern.compile("<(\\w+_notification)>");
 
     public static enum Type {
         BillingInfoUpdatedNotification(com.ning.billing.recurly.model.push.account.BillingInfoUpdatedNotification.class),

--- a/src/main/java/com/ning/billing/recurly/model/push/account/UpdatedAccountNotification.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/account/UpdatedAccountNotification.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model.push.account;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "updated_account_notification")
+public class UpdatedAccountNotification extends AccountNotification {
+
+    public static UpdatedAccountNotification read(final String payload) {
+        return read(payload, UpdatedAccountNotification.class);
+    }
+}

--- a/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
+++ b/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
@@ -142,6 +142,25 @@ public class TestRecurlyClient {
         }
     }
 
+    @Test(groups = "integration")
+    public void testGetBillingInfo() throws Exception {
+        final Account accountData = TestUtils.createRandomAccount();
+        final BillingInfo billingInfoData = TestUtils.createRandomBillingInfo();
+        billingInfoData.setAccount(null); // need to null out test account
+        accountData.setBillingInfo(billingInfoData);
+
+        try {
+            // Create account and fetch billing info
+            final Account account = recurlyClient.createAccount(accountData);
+            final BillingInfo retrievedBillingInfo = recurlyClient.getBillingInfo(account.getAccountCode());
+            Assert.assertNotNull(retrievedBillingInfo);
+            Assert.assertEquals(retrievedBillingInfo.getType(), "credit_card");
+        } finally {
+            // Close the account
+            recurlyClient.closeAccount(accountData.getAccountCode());
+        }
+    }
+
     @Test(groups = "integration", description = "See https://github.com/killbilling/recurly-java-library/issues/23")
     public void testRemoveSubscriptionAddons() throws Exception {
         final Account accountData = TestUtils.createRandomAccount();

--- a/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
+++ b/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
@@ -1654,6 +1654,59 @@ public class TestRecurlyClient {
     }
 
     @Test(groups = "integration")
+    public void testAuthorizePurchase() throws Exception {
+        final Plan planData = TestUtils.createRandomPlan(CURRENCY);
+        final Account accountData = TestUtils.createRandomAccount();
+        final BillingInfo billingInfoData = TestUtils.createRandomBillingInfo();
+        final Adjustments adjustmentsData = new Adjustments();
+        final Adjustment adjustmentData = TestUtils.createRandomAdjustment();
+        final GiftCard giftCardData = TestUtils.createRandomGiftCard();
+
+        giftCardData.setProductCode("test_gift_card");
+        giftCardData.setCurrency("USD");
+
+        adjustmentData.setCurrency(null); // this one accepted by site
+        adjustmentsData.add(adjustmentData);
+
+        billingInfoData.setAccount(null); // null out random account fixture
+        accountData.setBillingInfo(billingInfoData); // add the billing info to account data
+
+        // these 2 things are required by this endpoint
+        billingInfoData.setExternalHppType("adyen"); // set the external hpp collection to adyen
+        accountData.setEmail("benjamin.dumonde@example.com");
+
+        try {
+            final Plan plan = recurlyClient.createPlan(planData);
+            final GiftCard purchasedGiftCard = recurlyClient.purchaseGiftCard(giftCardData);
+            final GiftCard redemptionData = new GiftCard();
+            redemptionData.setRedemptionCode(purchasedGiftCard.getRedemptionCode());
+            final ArrayList<String> couponCodes = new ArrayList<String>(Arrays.asList("ascu2wprjk", "vttx1luuwz"));
+            final Subscription subscriptionData = new Subscription();
+            subscriptionData.setPlanCode(plan.getPlanCode());
+            final Subscriptions subscriptions = new Subscriptions();
+            subscriptions.add(subscriptionData);
+
+            final Purchase purchaseData = new Purchase();
+            purchaseData.setAccount(accountData);
+            purchaseData.setAdjustments(adjustmentsData);
+            purchaseData.setCollectionMethod("automatic");
+            purchaseData.setAdjustments(adjustmentsData);
+            purchaseData.setCurrency("USD");
+            purchaseData.setSubscriptions(subscriptions);
+            purchaseData.setGiftCard(redemptionData);
+            purchaseData.setCouponCodes(couponCodes);
+            purchaseData.setCustomerNotes("Customer Notes");
+            purchaseData.setTermsAndConditions("Terms and Conditions");
+            purchaseData.setVatReverseChargeNotes("VAT Reverse Charge Notes");
+
+            final Invoice invoice = recurlyClient.authorizePurchase(purchaseData);
+            Assert.assertNotNull(invoice.getUuid());
+        } finally {
+            recurlyClient.deletePlan(planData.getPlanCode());
+        }
+    }
+
+        @Test(groups = "integration")
     public void testAccountAcquisition() throws Exception {
         final Account accountData = TestUtils.createRandomAccount();
 

--- a/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
+++ b/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
@@ -1641,6 +1641,9 @@ public class TestRecurlyClient {
             purchaseData.setSubscriptions(subscriptions);
             purchaseData.setGiftCard(redemptionData);
             purchaseData.setCouponCodes(couponCodes);
+            purchaseData.setCustomerNotes("Customer Notes");
+            purchaseData.setTermsAndConditions("Terms and Conditions");
+            purchaseData.setVatReverseChargeNotes("VAT Reverse Charge Notes");
 
             final Invoice invoice = recurlyClient.purchase(purchaseData);
             Assert.assertNotNull(invoice.getInvoiceNumber());

--- a/src/test/java/com/ning/billing/recurly/TestUtils.java
+++ b/src/test/java/com/ning/billing/recurly/TestUtils.java
@@ -239,7 +239,6 @@ public class TestUtils {
         return "2020";
     }
 
-
     /**
      * Creates a random {@link com.ning.billing.recurly.model.Account} object for testing use.
      *

--- a/src/test/java/com/ning/billing/recurly/TestUtils.java
+++ b/src/test/java/com/ning/billing/recurly/TestUtils.java
@@ -223,19 +223,6 @@ public class TestUtils {
         return random.nextInt(upperRange);
     }
 
-    /**
-     * Returns a random 2 character country code.
-     *
-     * @param seed The RNG seed
-     * @return The random country code
-     */
-    public static String randomCountry(final int seed) {
-        Random random = new Random(seed);
-        final String[] countries = {"US", "CA", "MX", "IT", "CH"};
-        final int position = random.nextInt(countries.length);
-        return countries[position];
-    }
-
     public static String createTestCCNumber() {
         return "4111-1111-1111-1111";
     }
@@ -305,7 +292,7 @@ public class TestUtils {
         address.setCity(randomAlphaNumericString(10, seed));
         address.setState(randomAlphaString(2, seed).toUpperCase());
         address.setZip("94110");
-        address.setCountry(randomCountry(seed));
+        address.setCountry("US");
         address.setPhone(randomNumericString(10, seed));
 
         return address;
@@ -335,7 +322,7 @@ public class TestUtils {
         address.setState(randomAlphaString(2, seed).toUpperCase());
         address.setState(randomAlphaString(2, seed).toUpperCase());
         address.setZip("94110");
-        address.setCountry(randomCountry(seed));
+        address.setCountry("US");
         address.setPhone(randomNumericString(10, seed));
         address.setNickname(randomAlphaNumericString(10, seed));
         address.setFirstName(randomAlphaNumericString(10, seed));
@@ -402,7 +389,7 @@ public class TestUtils {
         info.setCity(randomAlphaNumericString(10, seed));
         info.setState("CA");
         info.setZip("94110");
-        info.setCountry(randomCountry(seed));
+        info.setCountry("US");
         info.setPhone(randomInteger(8, seed));
         info.setVatNumber(randomNumericString(8, seed));
         info.setYear(createTestCCYear());

--- a/src/test/java/com/ning/billing/recurly/TestUtils.java
+++ b/src/test/java/com/ning/billing/recurly/TestUtils.java
@@ -734,6 +734,9 @@ public class TestUtils {
         invoice.setCreatedAt(NOW);
         invoice.setCollectionMethod("credit_card");
         invoice.setNetTerms(randomInteger(100, seed));
+        invoice.setCustomerNotes("Customer Notes " + randomAlphaString(20, seed));
+        invoice.setTermsAndConditions("Terms and Conditions " + randomAlphaString(20, seed));
+        invoice.setVatReverseChargeNotes("VAT Reverse Charge Notes " + randomAlphaString(20, seed));
 
         Adjustments adjustments = new Adjustments();
         for (int i = 0; i < 3; i++) {

--- a/src/test/java/com/ning/billing/recurly/TestUtils.java
+++ b/src/test/java/com/ning/billing/recurly/TestUtils.java
@@ -223,6 +223,19 @@ public class TestUtils {
         return random.nextInt(upperRange);
     }
 
+    /**
+     * Returns a random 2 character country code.
+     *
+     * @param seed The RNG seed
+     * @return The random country code
+     */
+    public static String randomCountry(final int seed) {
+        Random random = new Random(seed);
+        final String[] countries = {"US", "CA", "MX", "IT", "CH"};
+        final int position = random.nextInt(countries.length);
+        return countries[position];
+    }
+
     public static String createTestCCNumber() {
         return "4111-1111-1111-1111";
     }
@@ -292,7 +305,7 @@ public class TestUtils {
         address.setCity(randomAlphaNumericString(10, seed));
         address.setState(randomAlphaString(2, seed).toUpperCase());
         address.setZip("94110");
-        address.setCountry(randomAlphaString(2, seed).toUpperCase());
+        address.setCountry(randomCountry(seed));
         address.setPhone(randomNumericString(10, seed));
 
         return address;
@@ -322,7 +335,7 @@ public class TestUtils {
         address.setState(randomAlphaString(2, seed).toUpperCase());
         address.setState(randomAlphaString(2, seed).toUpperCase());
         address.setZip("94110");
-        address.setCountry(randomAlphaString(2, seed).toUpperCase());
+        address.setCountry(randomCountry(seed));
         address.setPhone(randomNumericString(10, seed));
         address.setNickname(randomAlphaNumericString(10, seed));
         address.setFirstName(randomAlphaNumericString(10, seed));
@@ -389,7 +402,7 @@ public class TestUtils {
         info.setCity(randomAlphaNumericString(10, seed));
         info.setState("CA");
         info.setZip("94110");
-        info.setCountry("US");
+        info.setCountry(randomCountry(seed));
         info.setPhone(randomInteger(8, seed));
         info.setVatNumber(randomNumericString(8, seed));
         info.setYear(createTestCCYear());

--- a/src/test/java/com/ning/billing/recurly/model/TestPurchase.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestPurchase.java
@@ -34,6 +34,9 @@ public class TestPurchase extends TestModelBase {
                 "  <collection_method>automatic</collection_method>" +
                 "  <net_terms>30</net_terms>" +
                 "  <currency>USD</currency>" +
+                "  <customer_notes>Customer Notes</customer_notes>" +
+                "  <terms_and_conditions>Terms and Conditions</terms_and_conditions>" +
+                "  <vat_reverse_charge_notes>VAT Reverse Charge Notes</vat_reverse_charge_notes>" +
                 "  <account>" +
                 "    <account_code>test</account_code>" +
                 "    <billing_info>" +
@@ -78,6 +81,9 @@ public class TestPurchase extends TestModelBase {
         purchase.setCollectionMethod("automatic");
         purchase.setCurrency("USD");
         purchase.setNetTerms(30);
+        purchase.setCustomerNotes("Customer Notes");
+        purchase.setTermsAndConditions("Terms and Conditions");
+        purchase.setVatReverseChargeNotes("VAT Reverse Charge Notes");
 
         final Account account = new Account();
         account.setAccountCode("test");
@@ -124,8 +130,7 @@ public class TestPurchase extends TestModelBase {
         purchase.setCouponCodes(couponCodes);
         purchase.setGiftCard(giftCard);
 
-        final String xml = xmlMapper.writeValueAsString(purchase);
-        final Purchase purchaseExpected = xmlMapper.readValue(xml, Purchase.class);
+        final Purchase purchaseExpected = xmlMapper.readValue(purchaseData, Purchase.class);
 
         assertEquals(purchase, purchaseExpected);
     }

--- a/src/test/java/com/ning/billing/recurly/model/TestPurchase.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestPurchase.java
@@ -18,6 +18,7 @@
 package com.ning.billing.recurly.model;
 
 import com.ning.billing.recurly.TestUtils;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 import java.util.List;
 import java.util.ArrayList;
@@ -32,7 +33,7 @@ public class TestPurchase extends TestModelBase {
         final String purchaseData = "<purchase xmlns=\"\">" +
                 "<currency>USD</currency>" +
                 "  <collection_method>automatic</collection_method>" +
-                "  <net_terms>30</net_terms>" +
+                "  <net_terms type=\"integer\">30</net_terms>" +
                 "  <currency>USD</currency>" +
                 "  <customer_notes>Customer Notes</customer_notes>" +
                 "  <terms_and_conditions>Terms and Conditions</terms_and_conditions>" +
@@ -47,15 +48,15 @@ public class TestPurchase extends TestModelBase {
                 "      <state>CA</state>" +
                 "      <zip>94110</zip>" +
                 "      <country>US</country>" +
-                "      <year>2019</year>" +
-                "      <month>12</month>" +
+                "      <year type=\"integer\">2019</year>" +
+                "      <month type=\"integer\">12</month>" +
                 "      <number>4000-0000-0000-0000</number>" +
                 "    </billing_info>" +
                 "  </account>" +
                 "  <adjustments>" +
                 "    <adjustment>" +
-                "      <unit_amount_in_cents>1000</unit_amount_in_cents>" +
-                "      <quantity>1</quantity>" +
+                "      <unit_amount_in_cents type=\"integer\">1000</unit_amount_in_cents>" +
+                "      <quantity type=\"integer\">1</quantity>" +
                 "      <currency>USD</currency>" +
                 "      <product_code>product-code</product_code>" +
                 "    </adjustment>" +
@@ -77,62 +78,57 @@ public class TestPurchase extends TestModelBase {
                 "  </gift_card>" +
                 "</purchase>";
 
-        final Purchase purchase = new Purchase();
-        purchase.setCollectionMethod("automatic");
-        purchase.setCurrency("USD");
-        purchase.setNetTerms(30);
-        purchase.setCustomerNotes("Customer Notes");
-        purchase.setTermsAndConditions("Terms and Conditions");
-        purchase.setVatReverseChargeNotes("VAT Reverse Charge Notes");
+        // test serialization
+        final Purchase purchase = xmlMapper.readValue(purchaseData, Purchase.class);
+        verifyPurchase(purchase);
 
-        final Account account = new Account();
-        account.setAccountCode("test");
-
-        final BillingInfo billingInfo = new BillingInfo();
-        billingInfo.setAddress1("400 Alabama St");
-        billingInfo.setCity("San Francisco");
-        billingInfo.setCountry("US");
-        billingInfo.setFirstName("Benjamin");
-        billingInfo.setLastName("Du Monde");
-        billingInfo.setMonth(12);
-        billingInfo.setNumber("4000-0000-0000-0000");
-        billingInfo.setState("CA");
-        billingInfo.setYear(2019);
-        billingInfo.setZip("94110");
-        account.setBillingInfo(billingInfo);
-
-        final Adjustments adjustments = new Adjustments();
-        final Adjustment adjustment = new Adjustment();
-        adjustment.setCurrency("USD");
-        adjustment.setProductCode("product-code");
-        adjustment.setQuantity(1);
-        adjustment.setUnitAmountInCents(1000);
-        adjustments.add(adjustment);
-
-        final Subscriptions subscriptions = new Subscriptions();
-        final Subscription sub1 = new Subscription();
-        sub1.setPlanCode("plan1");
-        final Subscription sub2 = new Subscription();
-        sub2.setPlanCode("plan2");
-        subscriptions.add(sub1);
-        subscriptions.add(sub2);
-
-        final List<String> couponCodes = new ArrayList<String>();
-        couponCodes.add("coupon1");
-        couponCodes.add("coupon2");
-
-        final GiftCard giftCard = new GiftCard();
-        giftCard.setRedemptionCode("ABC1234");
-
-        purchase.setAccount(account);
-        purchase.setAdjustments(adjustments);
-        purchase.setSubscriptions(subscriptions);
-        purchase.setCouponCodes(couponCodes);
-        purchase.setGiftCard(giftCard);
-
+        // test deseralization
         final Purchase purchaseExpected = xmlMapper.readValue(purchaseData, Purchase.class);
-
         assertEquals(purchase, purchaseExpected);
+    }
+
+    public void verifyPurchase(final Purchase purchase) {
+        assertEquals(purchase.getCollectionMethod(), "automatic");
+        assertEquals(purchase.getCurrency(), "USD");
+        assertEquals(purchase.getNetTerms(), new Integer(30));
+        assertEquals(purchase.getCustomerNotes(), "Customer Notes");
+        assertEquals(purchase.getTermsAndConditions(), "Terms and Conditions");
+        assertEquals(purchase.getVatReverseChargeNotes(), "VAT Reverse Charge Notes");
+
+        final Account account = purchase.getAccount();
+        assertEquals(account.getAccountCode(), "test");
+
+
+        final BillingInfo billingInfo = purchase.getAccount().getBillingInfo();
+        assertEquals(billingInfo.getAddress1(), "400 Alabama St");
+        assertEquals(billingInfo.getCity(), "San Francisco");
+        assertEquals(billingInfo.getState(), "CA");
+        assertEquals(billingInfo.getCountry(), "US");
+        assertEquals(billingInfo.getZip(), "94110");
+        assertEquals(billingInfo.getFirstName(), "Benjamin");
+        assertEquals(billingInfo.getLastName(), "Du Monde");
+        assertEquals(billingInfo.getMonth(), new Integer(12));
+        assertEquals(billingInfo.getYear(), new Integer(2019));
+        assertEquals(billingInfo.getNumber(), "4000-0000-0000-0000");
+
+        final Adjustment adjustment = purchase.getAdjustments().get(0);
+        assertEquals(adjustment.getCurrency(), "USD");
+        assertEquals(adjustment.getProductCode(), "product-code");
+        assertEquals(adjustment.getQuantity(), new Integer(1));
+        assertEquals(adjustment.getUnitAmountInCents(), new Integer(1000));
+
+
+        final Subscription sub1 = purchase.getSubscriptions().get(0);
+        assertEquals(sub1.getPlanCode(), "plan1");
+        final Subscription sub2 = purchase.getSubscriptions().get(1);
+        assertEquals(sub2.getPlanCode(), "plan2");
+
+        final List<String> couponCodes = purchase.getCouponCodes();
+        assertEquals(couponCodes.get(0), "coupon1");
+        assertEquals(couponCodes.get(1), "coupon2");
+
+        final GiftCard giftCard = purchase.getGiftCard();
+        assertEquals(giftCard.getRedemptionCode(), "ABC1234");
     }
 
     @Test(groups = "fast")

--- a/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
@@ -69,6 +69,7 @@ public class TestSubscription extends TestModelBase {
                                         "  <started_with_gift type=\"boolean\">true</started_with_gift>\n" +
                                         "  <converted_at type=\"dateTime\">2017-06-27T00:00:00Z</converted_at>" +
                                         "  <no_billing_info_reason>plan_free_trial</no_billing_info_reason>" +
+                                        "  <imported_trial type=\"boolean\">true</imported_trial>" +
                                         "  <subscription_add_ons type=\"array\">\n" +
                                         "  </subscription_add_ons>\n" +
                                         "  <coupon_codes type=\"array\">\n" +
@@ -132,6 +133,7 @@ public class TestSubscription extends TestModelBase {
                                         "  <started_with_gift type=\"boolean\">true</started_with_gift>\n" +
                                         "  <converted_at type=\"dateTime\">2017-06-27T00:00:00Z</converted_at>" +
                                         "  <no_billing_info_reason>plan_free_trial</no_billing_info_reason>" +
+                                        "  <imported_trial type=\"boolean\">true</imported_trial>" +
                                         "  <subscription_add_ons type=\"array\">\n" +
                                         "    <subscription_add_on>\n" +
                                         "      <add_on_code>extra_users</add_on_code>\n" +
@@ -205,6 +207,7 @@ public class TestSubscription extends TestModelBase {
         Assert.assertEquals(subscription.getConvertedAt(), new DateTime("2017-06-27T00:00:00Z"));
         Assert.assertTrue(subscription.getStartedWithGift());
         Assert.assertEquals(subscription.getNoBillingInfoReason(), "plan_free_trial");
+        Assert.assertTrue(subscription.getImportedTrial());
 
         return subscription;
     }

--- a/src/test/java/com/ning/billing/recurly/model/push/TestNotification.java
+++ b/src/test/java/com/ning/billing/recurly/model/push/TestNotification.java
@@ -17,6 +17,7 @@
 
 package com.ning.billing.recurly.model.push;
 
+import com.ning.billing.recurly.model.push.account.*;
 import com.ning.billing.recurly.model.push.invoice.*;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
@@ -27,10 +28,6 @@ import org.testng.annotations.Test;
 import com.ning.billing.recurly.model.Account;
 import com.ning.billing.recurly.model.Plan;
 import com.ning.billing.recurly.model.TestModelBase;
-import com.ning.billing.recurly.model.push.account.AccountNotification;
-import com.ning.billing.recurly.model.push.account.BillingInfoUpdatedNotification;
-import com.ning.billing.recurly.model.push.account.CanceledAccountNotification;
-import com.ning.billing.recurly.model.push.account.NewAccountNotification;
 import com.ning.billing.recurly.model.push.payment.FailedPaymentNotification;
 import com.ning.billing.recurly.model.push.payment.PaymentNotification;
 import com.ning.billing.recurly.model.push.payment.PushTransaction;
@@ -267,6 +264,9 @@ public class TestNotification extends TestModelBase {
     public void testCanceledAccountNotification() {
         deserialize(CanceledAccountNotification.class);
     }
+
+    @Test(groups = "fast")
+    public void testUpdatedAccountNotification() { deserialize(UpdatedAccountNotification.class); }
 
     @Test(groups = "fast")
     public void testBillingInfoUpdatedNotification() {


### PR DESCRIPTION
This PR results from 
`git rebase --onto recurly-java-library-0.13.1 origin/master KP-92-rebase-recurly-lib`

and changing `version` and `jackson.version` in `pom.xml`.

Running
`mvn clean test -Pintegration -Dkillbill.payment.recurly.apiKey=xxxxxxxxxxxxxxxxxxxx -Dkillbill.payment.recurly.subDomain=kahoot-vagrant`

return 7 errors of 35 tests. The previous version `0.11.1-kahoot` had 6 errors in 33 tests and the new failing test was added after 0.11 

Running the tests in platform-rest-api shows that the API is now doing more validation (e.g. country code `USA` is no longer valid, `billing.state` needs to be set) So we also need to update our test-data.